### PR TITLE
Fix in file type detection

### DIFF
--- a/lib/suby.rb
+++ b/lib/suby.rb
@@ -30,8 +30,7 @@ module Suby
     end
 
     def video?(file)
-      type = MIME::Types.type_for(file.path).first
-      type and type.media_type == "video"
+      MIME::Types.type_for(file.path).map(&:media_type).include? "video"
     end
 
     def download_subtitles_for_file(file, options)


### PR DESCRIPTION
There was an error, for .mp4 first returned media_type was application, now it should be fixed.
