### PR TITLE
Quick fix for Ruby 2.0 breakage

### DIFF
--- a/lib/suby/downloader.rb
+++ b/lib/suby/downloader.rb
@@ -36,7 +36,10 @@ module Suby
     end
 
     def xmlrpc
+      return @xmlrpc if @xmlrpc
       @xmlrpc ||= XMLRPC::Client.new(self.class::SITE, self.class::XMLRPC_PATH)
+      @xmlrpc.http_header_extra = { 'accept-encoding' => 'identity' } if RbConfig::CONFIG['MAJOR'] == '2'
+      @xmlrpc
     end
 
     def get(path, initheader = {}, parse_response = true)


### PR DESCRIPTION
According to [this discussion](https://www.ruby-forum.com/topic/4412475) the XMLRPC library included with Ruby 2.0 has a bug that makes the Content-Length header inconsistent with the actual data. This quick & dirty patch checks for a Ruby version of 2 and avoids requesting compressed content. I haven't tried on other platforms, but it shouldn't hurt.
