### PR TITLE
Ruby 1.9.x doesn't have Net::ReadTimeout, so let's fix that.

### DIFF
--- a/lib/suby/downloader.rb
+++ b/lib/suby/downloader.rb
@@ -78,7 +78,9 @@ module Suby
     def download
       begin
         extract download_url
-      rescue Net.const_defined?(:ReadTimeout) ? Net::ReadTimeout : EOFError => error
+      rescue Timeout::Error, Errno::ECONNREFUSED, Errno::EINVAL,
+          Errno::ECONNRESET, EOFError, RuntimeError, Net::HTTPBadResponse,
+          Net::HTTPHeaderSyntaxError, Net::ProtocolError => error
         raise Suby::DownloaderError, error.message
       end
     end


### PR DESCRIPTION
Ruby 1.9.x doesn't have Net::ReadTimeout, so let's fix that.
