### PR TITLE
Fix ArgumentError for non-UTF8 locales

### DIFF
--- a/lib/suby.rb
+++ b/lib/suby.rb
@@ -4,6 +4,11 @@ require 'mime/types'
 
 Path.require_tree 'suby', except: %w[downloader/]
 
+if RUBY_VERSION =~ /1.9/
+  Encoding.default_external = Encoding::UTF_8
+  Encoding.default_internal = Encoding::UTF_8
+end
+
 module Suby
   NotFoundError = Class.new StandardError
   DownloaderError = Class.new StandardError


### PR DESCRIPTION
If locale settings are non UTF-8 and search results end up with UTF-8 characters, on Ruby 1.9 it will end up with:
  ArgumentError: invalid byte sequence in US-ASCII
Fix that by forcing UTF-8 everywhere.

Let me know what you think about this.
